### PR TITLE
Add resolution note modal on conversation resolve

### DIFF
--- a/app/javascript/dashboard/components/modals/ResolutionNoteModal.vue
+++ b/app/javascript/dashboard/components/modals/ResolutionNoteModal.vue
@@ -1,0 +1,53 @@
+<script setup>
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Editor from 'dashboard/components-next/Editor/Editor.vue';
+import Button from 'dashboard/components-next/button/Button.vue';
+
+const props = defineProps({
+  onClose: { type: Function, default: () => {} },
+});
+
+const emit = defineEmits(['save', 'close']);
+const show = defineModel('show', { type: Boolean, default: false });
+const { t } = useI18n();
+
+const note = ref('');
+
+const closeModal = () => {
+  show.value = false;
+  emit('close');
+  props.onClose();
+  note.value = '';
+};
+
+const onSave = () => {
+  emit('save', note.value);
+  closeModal();
+};
+</script>
+
+<template>
+  <woot-modal v-model:show="show" :on-close="closeModal">
+    <woot-modal-header :header-title="t('CONVERSATION.RESOLUTION_NOTE.TITLE')" />
+    <div class="p-8 flex flex-col gap-4">
+      <Editor
+        v-model="note"
+        :placeholder="t('CONVERSATION.RESOLUTION_NOTE.PLACEHOLDER')"
+        class="[&>div]:px-4"
+      />
+      <div class="flex justify-end gap-2">
+        <Button
+          faded
+          slate
+          :label="t('CONVERSATION.RESOLUTION_NOTE.CANCEL')"
+          @click="closeModal"
+        />
+        <Button
+          :label="t('CONVERSATION.RESOLUTION_NOTE.SAVE')"
+          @click="onSave"
+        />
+      </div>
+    </div>
+  </woot-modal>
+</template>

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
@@ -205,13 +205,14 @@ export default {
       this.contextMenu.x = null;
       this.contextMenu.y = null;
     },
-    onUpdateConversation(status, snoozedUntil) {
+    onUpdateConversation(status, snoozedUntil, note) {
       this.closeContextMenu();
       this.$emit(
         'updateConversationStatus',
         this.chat.id,
         status,
-        snoozedUntil
+        snoozedUntil,
+        note
       );
     },
     async onAssignAgent(agent) {

--- a/app/javascript/dashboard/components/widgets/conversation/contextMenu/Index.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/contextMenu/Index.vue
@@ -1,5 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
+import { inject } from 'vue';
 import {
   getSortedAgentsByAvailability,
   getAgentsByUpdatedPresence,
@@ -50,8 +51,10 @@ export default {
   ],
   setup() {
     const { isAdmin } = useAdmin();
+    const openResolutionNoteModal = inject('openResolutionNoteModal');
     return {
       isAdmin,
+      openResolutionNoteModal,
     };
   },
   data() {
@@ -180,8 +183,15 @@ export default {
     this.$store.dispatch('inboxAssignableAgents/fetch', [this.inboxId]);
   },
   methods: {
-    toggleStatus(status, snoozedUntil) {
-      this.$emit('updateConversation', status, snoozedUntil);
+    async toggleStatus(status, snoozedUntil) {
+      let note;
+      if (
+        status === wootConstants.STATUS_TYPE.RESOLVED &&
+        typeof this.openResolutionNoteModal === 'function'
+      ) {
+        note = await this.openResolutionNoteModal();
+      }
+      this.$emit('updateConversation', status, snoozedUntil, note);
     },
     async snoozeConversation() {
       await this.$store.dispatch('setContextMenuChatId', this.chatId);

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -123,6 +123,12 @@
       "DESCRIPTION": "Are you sure you want to delete this conversation?",
       "CONFIRM": "Delete"
     },
+    "RESOLUTION_NOTE": {
+      "TITLE": "Add resolution note",
+      "PLACEHOLDER": "Type the reason for resolving",
+      "SAVE": "Save",
+      "CANCEL": "Cancel"
+    },
     "CARD_CONTEXT_MENU": {
       "PENDING": "Mark as pending",
       "RESOLVED": "Mark as resolved",


### PR DESCRIPTION
## Summary
- add ResolutionNoteModal component to capture notes
- localize resolution note strings
- require note entry when resolving conversations via ResolveAction
- support resolution notes from context menus
- handle resolution note workflow inside ChatList provider

## Testing
- `pnpm eslint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.2.0.tgz)*
- `bundle exec rubocop -A` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_684ccf1984b08321a49040168c55831f