### PR TITLE
Add CRM link to sidebar

### DIFF
--- a/app/javascript/dashboard/components/layout/config/sidebarItems/primaryMenu.js
+++ b/app/javascript/dashboard/components/layout/config/sidebarItems/primaryMenu.js
@@ -18,6 +18,13 @@ const primaryMenuItems = accountId => [
     toStateName: 'home',
   },
   {
+    icon: 'link-outline',
+    key: 'crm',
+    label: 'CRM',
+    openInNewPage: true,
+    toState: 'https://crm.cruzeirodosulrj.com/',
+  },
+  {
     icon: 'captain',
     key: 'captain',
     label: 'CAPTAIN',

--- a/app/javascript/dashboard/components/layout/sidebarComponents/Primary.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/Primary.vue
@@ -88,6 +88,7 @@ export default {
         :name="menuItem.label"
         :to="menuItem.toState"
         :is-child-menu-active="menuItem.key === activeMenuItem"
+        :open-in-new-page="menuItem.openInNewPage"
       />
     </div>
     <div class="flex flex-col items-center justify-end pb-6">

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -272,6 +272,7 @@
     "SWITCH": "Switch",
     "INBOX_VIEW": "Inbox View",
     "CONVERSATIONS": "Conversations",
+    "CRM": "CRM",
     "INBOX": "My Inbox",
     "ALL_CONVERSATIONS": "All Conversations",
     "MENTIONED_CONVERSATIONS": "Mentions",


### PR DESCRIPTION
## Summary
- add new CRM link in primary navigation just below Conversations
- support opening external links from PrimaryNavItem
- expose new `CRM` label in English locale

## Testing
- `pnpm eslint` *(fails: unable to fetch pnpm)*
- `bundle exec rubocop -A` *(fails: ruby version not installed)*
- `pnpm test` *(fails: unable to fetch pnpm)*
- `bundle exec rspec spec/models` *(fails: ruby version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684cd468e68483219ca3b56fc84346de