### PR TITLE
feat: show label for deleted dashboard messages

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,6 +3,8 @@ name: Build and Push Docker Image
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docker-compose.production.yaml'
 
 jobs:
   build:

--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
   def destroy
     ActiveRecord::Base.transaction do
-      message.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: { deleted: true })
+      message.update!(content_attributes: message.content_attributes.merge(deleted: true))
       message.attachments.destroy_all
     end
   end

--- a/app/javascript/dashboard/components-next/message/bubbles/Base.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Base.vue
@@ -10,8 +10,15 @@ import { useI18n } from 'vue-i18n';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import { MESSAGE_VARIANTS, ORIENTATION } from '../constants';
 
-const { variant, orientation, inReplyTo, shouldGroupWithNext } =
-  useMessageContext();
+const {
+  variant,
+  orientation,
+  inReplyTo,
+  shouldGroupWithNext,
+  contentAttributes,
+} = useMessageContext();
+
+const isDeleted = computed(() => contentAttributes.value?.deleted);
 const { t } = useI18n();
 
 const varaintBaseMap = {
@@ -101,6 +108,9 @@ const replyToPreview = computed(() => {
       </span>
     </div>
     <slot />
+    <span v-if="isDeleted" class="text-xs text-n-slate-11">
+      {{ t('CONVERSATION.DELETED_MESSAGE') }}
+    </span>
     <MessageMeta
       v-if="!shouldGroupWithNext && variant !== MESSAGE_VARIANTS.ACTIVITY"
       :class="[

--- a/app/javascript/dashboard/components/widgets/conversation/Message.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/Message.vue
@@ -548,6 +548,9 @@ export default {
           :inbox-id="data.inbox_id"
           :created-at="createdAt"
         />
+        <span v-if="isMessageDeleted" class="text-xs text-n-slate-11">
+          {{ $t('CONVERSATION.DELETED_MESSAGE') }}
+        </span>
       </div>
       <Spinner v-if="isPending" size="tiny" />
       <div

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -57,6 +57,7 @@
     "UNSUPPORTED_MESSAGE_INSTAGRAM": "This message is unsupported. You can view this message on the Instagram app.",
     "SUCCESS_DELETE_MESSAGE": "Message deleted successfully",
     "FAIL_DELETE_MESSSAGE": "Couldn't delete message! Try again",
+    "DELETED_MESSAGE": "This message was deleted",
     "NO_RESPONSE": "No response",
     "RESPONSE": "Response",
     "RATING_TITLE": "Rating",

--- a/app/services/instagram/base_message_text.rb
+++ b/app/services/instagram/base_message_text.rb
@@ -55,7 +55,7 @@ class Instagram::BaseMessageText < Instagram::WebhooksBaseService
     return if message_to_delete.blank?
 
     message_to_delete.attachments.destroy_all
-    message_to_delete.update!(content: I18n.t('conversations.messages.deleted'), deleted: true)
+    message_to_delete.update!(deleted: true)
   end
 
   # Methods to be implemented by subclasses


### PR DESCRIPTION
## Summary
- keep deleted messages but mark them deleted instead of replacing the content
- show a deleted message label in dashboard message bubbles
- include frontend translation for deleted state
- skip docker build workflow when only docker-compose file changes

## Testing
- `bundle install` *(fails: rbenv 3.3.3 not installed)*
- `pnpm install` *(fails: fetch failed)*
- `pnpm eslint` *(fails: fetch failed)*
- `bundle exec rubocop -a` *(fails: rbenv 3.3.3 not installed)*
- `pnpm test` *(fails: fetch failed)*
- `bundle exec rspec spec` *(fails: rbenv 3.3.3 not installed)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684cd907dd68832193566e2f22a9329d