### PR TITLE
Add label requirement before resolution

### DIFF
--- a/app/javascript/dashboard/components/buttons/ResolveAction.vue
+++ b/app/javascript/dashboard/components/buttons/ResolveAction.vue
@@ -113,7 +113,19 @@ const onCmdOpenConversation = () => {
   toggleStatus(wootConstants.STATUS_TYPE.OPEN);
 };
 
+const conversationLabels = computed(() => {
+  return (
+    store.getters['conversationLabels/getConversationLabels'](
+      currentChat.value.id
+    ) || []
+  );
+});
+
 const onCmdResolveConversation = () => {
+  if (!conversationLabels.value.length) {
+    useAlert(t('CONVERSATION.LABEL_REQUIRED_TO_RESOLVE'));
+    return;
+  }
   showResolutionNoteModal.value = true;
 };
 

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -223,6 +223,7 @@
     "CHANGE_TEAM": "Conversation team changed",
     "SUCCESS_DELETE_CONVERSATION": "Conversation deleted successfully",
     "FAIL_DELETE_CONVERSATION": "Couldn't delete conversation! Try again",
+    "LABEL_REQUIRED_TO_RESOLVE": "Please add at least one label before resolving the conversation",
     "FILE_SIZE_LIMIT": "File exceeds the {MAXIMUM_SUPPORTED_FILE_UPLOAD_SIZE} MB attachment limit",
     "MESSAGE_ERROR": "Unable to send this message, please try again later",
     "SENT_BY": "Sent by:",


### PR DESCRIPTION
## Summary
- ask for at least one label when resolving a conversation
- add i18n string for missing label error

## Testing
- `bundle exec rubocop -a` *(fails: command not found)*
- `pnpm eslint` *(fails: fetch failed)*
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851ff5e80d48321824b806077ec17f2