### PR TITLE
Add label requirement before resolution

### DIFF
--- a/app/javascript/dashboard/components/buttons/ResolveAction.vue
+++ b/app/javascript/dashboard/components/buttons/ResolveAction.vue
@@ -95,12 +95,17 @@ const toggleStatus = (status, snoozedUntil) => {
 };
 
 const onSaveResolutionNote = async note => {
+  if (!conversationLabels.value.length) {
+    useAlert(t('CONVERSATION.LABEL_REQUIRED_TO_RESOLVE'));
+    return;
+  }
   noteText = note;
-  if (!noteText) return;
-  await store.dispatch('contactNotes/create', {
-    contactId: currentChat.value.meta.sender.id,
-    content: noteText,
-  });
+  if (noteText) {
+    await store.dispatch('contactNotes/create', {
+      contactId: currentChat.value.meta.sender.id,
+      content: noteText,
+    });
+  }
   toggleStatus(wootConstants.STATUS_TYPE.RESOLVED);
 };
 
@@ -112,6 +117,14 @@ const onCloseResolutionNote = () => {
 const onCmdOpenConversation = () => {
   toggleStatus(wootConstants.STATUS_TYPE.OPEN);
 };
+
+const conversationLabels = computed(() => {
+  return (
+    store.getters['conversationLabels/getConversationLabels'](
+      currentChat.value.id
+    ) || []
+  );
+});
 
 const onCmdResolveConversation = () => {
   showResolutionNoteModal.value = true;

--- a/app/javascript/dashboard/components/modals/ResolutionNoteModal.vue
+++ b/app/javascript/dashboard/components/modals/ResolutionNoteModal.vue
@@ -3,6 +3,9 @@ import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Editor from 'dashboard/components-next/Editor/Editor.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
+import AddLabel from 'shared/components/ui/dropdown/AddLabel.vue';
+import LabelDropdown from 'shared/components/ui/label/LabelDropdown.vue';
+import { useConversationLabels } from 'dashboard/composables/useConversationLabels';
 
 const props = defineProps({
   onClose: { type: Function, default: () => {} },
@@ -14,11 +17,30 @@ const { t } = useI18n();
 
 const note = ref('');
 
+const {
+  savedLabels,
+  activeLabels,
+  accountLabels,
+  addLabelToConversation,
+  removeLabelFromConversation,
+} = useConversationLabels();
+
+const showLabelDropdown = ref(false);
+
+const toggleLabels = () => {
+  showLabelDropdown.value = !showLabelDropdown.value;
+};
+
+const closeDropdownLabel = () => {
+  showLabelDropdown.value = false;
+};
+
 const closeModal = () => {
   show.value = false;
   emit('close');
   props.onClose();
   note.value = '';
+  closeDropdownLabel();
 };
 
 const onSave = () => {
@@ -36,6 +58,34 @@ const onSave = () => {
         :placeholder="t('CONVERSATION.RESOLUTION_NOTE.PLACEHOLDER')"
         class="[&>div]:px-4"
       />
+      <div
+        v-on-clickaway="closeDropdownLabel"
+        class="flex flex-wrap items-start gap-1 relative"
+      >
+        <AddLabel @add="toggleLabels" />
+        <woot-label
+          v-for="label in activeLabels"
+          :key="label.id"
+          :title="label.title"
+          :description="label.description"
+          show-close
+          :color="label.color"
+          variant="smooth"
+          class="max-w-[calc(100%-0.5rem)]"
+          @remove="removeLabelFromConversation"
+        />
+        <div
+          v-if="showLabelDropdown"
+          class="absolute left-0 top-full mt-1 w-full z-10"
+        >
+          <LabelDropdown
+            :account-labels="accountLabels"
+            :selected-labels="savedLabels"
+            @add="addLabelToConversation"
+            @remove="removeLabelFromConversation"
+          />
+        </div>
+      </div>
       <div class="flex justify-end gap-2">
         <Button
           faded

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -223,6 +223,7 @@
     "CHANGE_TEAM": "Conversation team changed",
     "SUCCESS_DELETE_CONVERSATION": "Conversation deleted successfully",
     "FAIL_DELETE_CONVERSATION": "Couldn't delete conversation! Try again",
+    "LABEL_REQUIRED_TO_RESOLVE": "Please add at least one label before resolving the conversation",
     "FILE_SIZE_LIMIT": "File exceeds the {MAXIMUM_SUPPORTED_FILE_UPLOAD_SIZE} MB attachment limit",
     "MESSAGE_ERROR": "Unable to send this message, please try again later",
     "SENT_BY": "Sent by:",


### PR DESCRIPTION
## Summary
- allow adding labels in resolution note popup
- check that a label exists before resolving

## Testing
- `bundle exec rubocop -a` *(fails: command not found)*
- `pnpm eslint` *(fails: fetch failed)*
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851ff5e80d48321824b806077ec17f2