### PR TITLE
Fix label controls logic

### DIFF
--- a/app/javascript/dashboard/components/modals/ResolutionNoteModal.vue
+++ b/app/javascript/dashboard/components/modals/ResolutionNoteModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useAlert } from 'dashboard/composables';
 import Editor from 'dashboard/components-next/Editor/Editor.vue';
@@ -27,6 +27,20 @@ const {
 } = useConversationLabels();
 
 const showLabelDropdown = ref(false);
+const initialLabels = ref([]);
+
+watch(
+  () => show.value,
+  newVal => {
+    if (newVal) {
+      initialLabels.value = [...savedLabels.value];
+    }
+  }
+);
+
+const hasNewLabel = computed(() =>
+  savedLabels.value.some(label => !initialLabels.value.includes(label))
+);
 
 const toggleLabels = () => {
   showLabelDropdown.value = !showLabelDropdown.value;
@@ -56,7 +70,9 @@ const onSave = () => {
 
 <template>
   <woot-modal v-model:show="show" :on-close="closeModal">
-    <woot-modal-header :header-title="t('CONVERSATION.RESOLUTION_NOTE.TITLE')" />
+    <woot-modal-header
+      :header-title="t('CONVERSATION.RESOLUTION_NOTE.TITLE')"
+    />
     <div class="p-8 flex flex-col gap-4">
       <Editor
         v-model="note"
@@ -79,10 +95,7 @@ const onSave = () => {
           class="max-w-[calc(100%-0.5rem)]"
           @remove="removeLabelFromConversation"
         />
-        <div
-          v-if="showLabelDropdown"
-          class="absolute left-0 top-full mt-1 w-full z-10"
-        >
+        <div v-if="showLabelDropdown" class="w-full mt-1 z-10">
           <LabelDropdown
             :account-labels="accountLabels"
             :selected-labels="savedLabels"
@@ -99,34 +112,11 @@ const onSave = () => {
           @click="closeModal"
         />
         <Button
+          v-if="hasNewLabel"
           :label="t('CONVERSATION.RESOLUTION_NOTE.SAVE')"
           @click="onSave"
         />
-        <div
-          v-if="showLabelDropdown"
-          class="absolute left-0 top-full mt-1 w-full z-10"
-        >
-          <LabelDropdown
-            :account-labels="accountLabels"
-            :selected-labels="savedLabels"
-            @add="addLabelToConversation"
-            @remove="removeLabelFromConversation"
-          />
-        </div>
       </div>
-  <div class="flex justify-end gap-2">
-    <Button
-      faded
-      slate
-      :label="t('CONVERSATION.RESOLUTION_NOTE.CANCEL')"
-      @click="closeModal"
-    />
-    <Button
-      v-if="activeLabels.length"
-      :label="t('CONVERSATION.RESOLUTION_NOTE.SAVE')"
-      @click="onSave"
-    />
-  </div>
     </div>
   </woot-modal>
 </template>


### PR DESCRIPTION
## Summary
- track initial labels when modal opens
- show save button only when a new label is added
- prevent dropdown from overlapping action buttons

## Testing
- `bundle exec rubocop -a` *(fails: command not found)*
- `pnpm install` *(fails: network access restricted)*
- `pnpm eslint` *(fails: network access restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68522c1f147c8321a0b0b1e5ff0d2dd4